### PR TITLE
Add local DeepSeek via Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,19 @@ python tempest_pipeline.py --target_model <target_model> --pipeline_model <pipel
 python get_metrics.py <results_json>
 ```
 
+#### Using a Local Ollama Model
+
+If you run a model locally with [Ollama](https://github.com/ollama/ollama), prefix the
+model name with `local/` and ensure the Ollama server is running. For example:
+
+```bash
+# Use a locally hosted DeepSeek model
+python tempest_pipeline.py --target_model local/deepseek-llm-r1-8b --pipeline_model local/deepseek-llm-r1-8b --results_json results.json
+```
+
+Set the `OLLAMA_BASE_URL` environment variable if your server is not available at
+`http://localhost:11434`.
+
 ## 6. Citation
 
 ```bibtex

--- a/tempest/conversation_attack.py
+++ b/tempest/conversation_attack.py
@@ -808,6 +808,17 @@ def llmclient_generate_conversation(self, messages: List[Dict[str, str]], max_to
         conversation_text += "Assistant:"
         response = self.generate(conversation_text, max_tokens=max_tokens, temperature=temperature)
         return response.strip()
+
+    elif self.client_type == "ollama":
+        url = f"{self.base_url}/api/chat"
+        data = {"model": self.model_name, "messages": messages, "stream": False, "temperature": temperature, "num_predict": max_tokens}
+        response = self.session.post(url, json=data)
+        response.raise_for_status()
+        res_json = response.json()
+        if isinstance(res_json, dict):
+            message = res_json.get("message") or {}
+            return message.get("content", res_json.get("response", "")).strip()
+        return ""
     else:
         raise ValueError(f"Client type {self.client_type} does not support conversation format.")
 


### PR DESCRIPTION
## Summary
- allow specifying `local/<model>` to use a locally hosted Ollama model
- implement Ollama request handling in `LLMClient`
- add matching conversation support
- document how to run Tempest with a local model in the README

## Testing
- `python -m py_compile tempest/llm_client.py tempest/conversation_attack.py`

------
https://chatgpt.com/codex/tasks/task_e_683f6f05f1a48328b4d9af4f5832cd11